### PR TITLE
<feat> friends page structure without searching feature

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
 </body> -->
 <body>
     <nav class="nav">
-        <a href = "/" class="nave__link" data-link></a>
+        <a href = "/" class="nave__link" data-link></a><br>
         <a href = "/login" class="nave__link" data-link>Login</a><br>
         <a href = "/dashboard" class="nave__link" data-link>Dashboard</a><br>
         <a href = "/profile" class="nave__link" data-link>Profile</a><br>

--- a/frontend/mock.json
+++ b/frontend/mock.json
@@ -1,6 +1,0 @@
-// this will be deleted later. This is just for testing purposes for POSTMAN
-// {
-//     "id": "1",
-//     "username": "user",
-// 	"password": "123"
-// }

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -15,14 +15,6 @@
   width: 800px;
 }
 
-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: rgb(255, 255, 255);
-  margin-bottom: 20px;
-}
-
 header h1 {
   font-size: 3em;
   letter-spacing: 5px;
@@ -83,6 +75,14 @@ main {
   top: calc(50% - 10px);
 } */
 
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: rgb(255, 255, 255);
+  margin-bottom: 20px;
+}
+
 body {
   --nav-width: 200px;
   margin: 0 0 0 var(--nav-width);
@@ -121,3 +121,59 @@ a {
   color: #009579;
 }
 
+.friend {
+  margin-left: 5px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 10px;
+}
+
+.friend img {
+	border-radius: 50%;
+	width: 50px;
+	height: 50px;
+	margin-right: 10px;
+}
+
+.friend .status {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	margin-left: 10px;
+}
+
+.friend a {
+  color: #060606;
+}
+
+.friends-profile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background-color: #f9f9f9;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin: 20px;
+}
+
+.friends-profile img {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  border: 4px solid #ddd;
+  margin-bottom: 15px;
+}
+
+.online-status {
+  display: flex;
+  align-items: center;
+  margin: 5px ;
+}
+
+.friends-profile .status {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	margin-left: 5px;
+}

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -35,6 +35,14 @@ nav button {
   margin: 0 10px;
 }
 
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: rgb(255, 255, 255);
+  margin-bottom: 20px;
+}
+
 main {
   display: flex;
   justify-content: center;
@@ -75,12 +83,10 @@ main {
   top: calc(50% - 10px);
 } */
 
-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: rgb(255, 255, 255);
-  margin-bottom: 20px;
+h1 {
+  font-size: 40px;
+  letter-spacing: 1px;
+  margin-left: 5px;
 }
 
 body {
@@ -90,24 +96,35 @@ body {
   font-size: 18px;
 }
 
+p {
+  margin-left: 10px;
+}
+
 .nav {
   position: fixed;
+  padding: 10px;
   top: 0;
   left: 0;
-  width: var(--nav-width);
+  width: 180px;
   height: 100vh;
   background: #222222;
+  text-align: center;
 }
 
-.nav__link {
-  display: block;
-  padding: 12px 18px;
+.nav a {
+  color: #dbe4cc;
   text-decoration: none;
-  color: #eeeeee;
-  font-weight: 500;
+  font-size: 20px;
+  display: inline-block;
+  padding: 6px 12px;
+  margin: 0 10px;
+  transition: background-color 0.3s ease;
 }
 
-.nav__link:hover {
+/* .nav__link {
+  text-decoration: none; */
+
+.nav a:hover {
   background: rgba(255, 255, 255, 0.05);
 }
 

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -71,11 +71,11 @@ const router = async () => {
 	}
 
 	//comment out to remove login for testing
-	if (match.route.authRequired && !window.isLoggedIn) {
-		console.log(`Access to ${match.route.path} is restricted.`);
-		navigateTo("/login");
-		return;
-	}
+	// if (match.route.authRequired && !window.isLoggedIn) {
+	// 	console.log(`Access to ${match.route.path} is restricted.`);
+	// 	navigateTo("/login");
+	// 	return;
+	// }
 	const view = new match.route.view(getParams(match));
 
 	view.getHtml();

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -71,11 +71,11 @@ const router = async () => {
 	}
 
 	//comment out to remove login for testing
-	// if (match.route.authRequired && !window.isLoggedIn) {
-	// 	console.log(`Access to ${match.route.path} is restricted.`);
-	// 	navigateTo("/login");
-	// 	return;
-	// }
+	if (match.route.authRequired && !window.isLoggedIn) {
+		console.log(`Access to ${match.route.path} is restricted.`);
+		navigateTo("/login");
+		return;
+	}
 	const view = new match.route.view(getParams(match));
 
 	view.getHtml();

--- a/frontend/static/js/views/AView.js
+++ b/frontend/static/js/views/AView.js
@@ -13,6 +13,11 @@ export default class {
 		return "";
 	}
 
+	clearView() {
+		const container = document.querySelector('main');
+		container.innerHTML = '';
+	}
+
 	updateView(...elements){
 		const container = document.querySelector('main');
 		const canvas = document.querySelector('canvas');
@@ -37,6 +42,7 @@ export default class {
     createParagraph(text) {
         const p = document.createElement('p');
         p.textContent = text;
+		p.innerHTML = text.replace(/\t/g, '&emsp;&emsp;');
         return p;
     }
 
@@ -75,6 +81,19 @@ export default class {
 		return button;
 	}
 
+	async fetchJsonData(url) {
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error(`HTTP error status: ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error("Failed to fetch JSON data:", error);
+            return null;
+        }
+    }
+
 	createGame(name){
 		// Create the game div
 		const gameDiv = document.createElement('div');
@@ -92,6 +111,4 @@ export default class {
 		// Return the game div for potential further manipulation
 		return gameDiv;
 	}
-	
-
 }

--- a/frontend/static/js/views/AView.js
+++ b/frontend/static/js/views/AView.js
@@ -36,6 +36,7 @@ export default class {
 	createHeader(text, headerSize) {
 		const header = document.createElement(headerSize);
         header.textContent = text;
+		header.className = 'h1';
         return header;
     }
 
@@ -43,6 +44,7 @@ export default class {
         const p = document.createElement('p');
         p.textContent = text;
 		p.innerHTML = text.replace(/\t/g, '&emsp;&emsp;');
+		p.className = 'p';
         return p;
     }
 

--- a/frontend/static/js/views/Friends.js
+++ b/frontend/static/js/views/Friends.js
@@ -2,15 +2,89 @@ import AView from "./AView.js";
 
 export default class extends AView {
 	constructor(params){
-		super(params);//call the constructor of the parent class
+		super(params);
 		this.setTitle("Friends");
 	}
 
 	async getHtml(){
-		const friends = this.createHeader('friends', 'h2');
-		const p = this.createParagraph('You have no friends');
+		const friends = this.createHeader('Friends', 'h1');
+		const data = await this.fetchJsonData('static/js/views/friends.json');
 
-		this.updateView(friends, p);
-		return ;
+		if (data && data.length > 0) {
+			const friendsList = document.createElement('div');
+			data.forEach(friend => {
+				const friendDiv = document.createElement('div');
+				friendDiv.classList.add('friend');
+
+				const avatar = document.createElement('img');
+				avatar.src = friend.profile.avatar;
+				avatar.alt = `${friend.username}'s avatar`;
+				friendDiv.appendChild(avatar);
+
+				const username = this.createParagraph(friend.username);
+
+				const usernameLink = document.createElement('a');
+				usernameLink.textContent = friend.username;
+				//using hash for SPA navigation
+				usernameLink.href = `#friends/${friend.id}`;
+				usernameLink.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    this.navigateToFriendsProfile(friend);
+                });
+				friendDiv.appendChild(usernameLink);
+
+				const status = document.createElement('div');
+				status.classList.add('status');
+				status.style.backgroundColor = friend.profile.online ? 'green' : 'gray';
+				friendDiv.appendChild(status);
+
+				friendsList.appendChild(friendDiv);
+			});
+
+			this.updateView(friends, friendsList);
+		} else {
+			const noFriendsMessage = this.createParagraph('You have no friends');
+			this.updateView(friends, noFriendsMessage);
+		}
+	}
+
+	navigateToFriendsProfile(friend) {
+	
+		history.pushState(null, null, `#friends/${friend.id}`);
+		this.clearView();
+	
+		const profileHeader = this.createHeader('Friends', 'h1');
+	
+		const profileView = document.createElement('div');
+		profileView.classList.add('friends-profile');
+	
+		const profileTitle = this.createHeader(`${friend.username}`, 'h3');
+		
+		const profileAvatar = document.createElement('img');
+		profileAvatar.src = friend.profile.avatar;
+		profileAvatar.alt = `${friend.username}'s avatar`;
+	
+		// const onlineStatus = this.createParagraph(`Online: ${friend.profile.online ? 'Yes' : 'No'}`);
+		const onlineStatus = document.createElement('div');
+        onlineStatus.classList.add('online-status');
+        const statusDot = document.createElement('div');
+        statusDot.classList.add('status');
+		statusDot.style.backgroundColor = friend.profile.online ? 'green' : 'gray';
+        const statusText = document.createElement('span');
+        statusText.textContent = `Online: ${friend.profile.online ? 'Yes' : 'No'}`;
+		onlineStatus.appendChild(statusText);
+		onlineStatus.appendChild(statusDot);
+
+		const winning = friend.wins;
+		const losing = friend.loses;
+
+		const gameHistory = this.createParagraph(`Win : ${friend.wins}🏆\t\tLoss : ${friend.loses}💀`)
+
+		profileView.appendChild(profileTitle);
+		profileView.appendChild(profileAvatar);
+		profileView.appendChild(onlineStatus);
+		profileView.appendChild(gameHistory);
+
+		this.updateView(profileHeader, profileView);
 	}
 }

--- a/frontend/static/js/views/Login.js
+++ b/frontend/static/js/views/Login.js
@@ -11,7 +11,7 @@ export default class extends AView {
 	}
 
 	async getHtml(){
-		const title = this.createHeader('Log in', 'h2');
+		const title = this.createHeader('Log in', 'h1');
 		title.classList.add('text-center');
 	
 		const form = this.createForm('loginform');

--- a/frontend/static/js/views/Profile.js
+++ b/frontend/static/js/views/Profile.js
@@ -47,6 +47,6 @@ export default class extends AView {
         const friends = this.createParagraphWithLink("Checkout who is online", "/friends");
 
 		this.updateView(header, userName, userEmail, profilePicutre, message, stats, settings, friends);
-		return container;
+		return ;
 	}
 }

--- a/frontend/static/js/views/Register.js
+++ b/frontend/static/js/views/Register.js
@@ -10,7 +10,7 @@ export default class extends AView {
 
 	async getHtml(){
 
-		const title = this.createHeader('Register', 'h2');
+		const title = this.createHeader('Register', 'h1');
 		title.classList.add('text-center');
 
 		const form = this.createForm('registerform');

--- a/frontend/static/js/views/friends.json
+++ b/frontend/static/js/views/friends.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "2",
+        "username": "john_doe",
+        "profile": {
+            "avatar": "https://picsum.photos/200",
+            "online": true
+        },
+        "wins": "2",
+        "loses": "3"
+    },
+    {
+        "id": "3",
+        "username": "jane_doe",
+        "profile": {
+            "avatar": "https://picsum.photos/200",
+            "online": false
+        },
+        "wins": "4",
+        "loses": "1"
+    }
+]


### PR DESCRIPTION
Friends page structure is done. Currently, it reads from friends.json file that is inside of static/js/views/friends.json. 

In Aview.js, fetchJsonData function is added and it is using URL. URL would be the endpoint of our REST API, probably something like 'http://localhost:3000/api/friends/' for example. At the moment, I am using fetchJsonData function in Friends.js but with the path to friends.json file. 

Some design has changed for better viewing purpose only. Not to make it pretty, some Aview classnames are added for css file.

Search for adding friends part hasn't added yet, it will be included from the different branch.