### PR TITLE
docs (api documentation): add swagger and redoc api docs with drf-spectacular

### DIFF
--- a/backend/django_backend/django_backend/settings.py
+++ b/backend/django_backend/django_backend/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'drf_spectacular'
 ]
 
 MIDDLEWARE = [
@@ -160,6 +161,7 @@ REST_FRAMEWORK = {
 	'DEFAULT_AUTHENTICATION_CLASSES': [
 		'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
+	'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 SIMPLE_JWT = {

--- a/backend/django_backend/django_backend/urls.py
+++ b/backend/django_backend/django_backend/urls.py
@@ -25,7 +25,7 @@ from rest_framework_simplejwt.views import (
 
 from rest_framework import routers
 from user.views import UserViewSet
-# from rest_demo import views as rest_views
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 router = routers.DefaultRouter()
 # router.register(r'users', rest_views.UserViewSet, basename='users')
@@ -40,7 +40,10 @@ urlpatterns = [
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('profile/', include('user.urls')),
     path('friends/', include('friends.urls')),
-    path('matches/', include('match.urls'))
+    path('matches/', include('match.urls')),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/django_backend/match/views.py
+++ b/backend/django_backend/match/views.py
@@ -6,14 +6,30 @@ from .serializers import MatchSerializer
 from django.contrib.auth.models import User
 from user.permissions import IsAuthenticatedOrCreateOnly
 
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample
+from drf_spectacular.types import OpenApiTypes
+
 class MatchListView(APIView):
     permission_classes = [IsAuthenticatedOrCreateOnly]
 
+    @extend_schema(
+        description='Get all matches.',
+        responses={
+            200: MatchSerializer(many=True)
+        }
+    )
     def get(self, request, format=None):
         matches = Match.objects.all()
         serializer = MatchSerializer(matches, many=True)
         return Response(serializer.data)
 
+    @extend_schema(
+        description='Create a new match.',
+        request=MatchSerializer,
+        responses={
+            201: MatchSerializer
+        }
+    )
     def post(self, request, format=None):
         serializer = MatchSerializer(data=request.data)
         if(serializer.is_valid()):
@@ -24,6 +40,56 @@ class MatchListView(APIView):
 class PlayerMatchListView(APIView):
     permissions_classes = [IsAuthenticatedOrCreateOnly]
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name='user_id',
+                description='User ID',
+                required=True,
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH
+            )
+        ],
+       responses={
+           200: MatchSerializer(many=True)
+       },
+       description='Get all matches for a player.',
+       examples=[
+              OpenApiExample(
+                'Get all matches for a player',
+                value={
+                        "id": 1,
+                        "player1": {
+                            "id": 1,
+                            "username": "test1",
+                            "avatar": {
+                                "image": "string",
+                                "uploaded_on": "2024-07-12T10:45:29.531147Z"
+                            }
+                        },
+                        "player2": {
+                            "id": 3,
+                            "username": "Brooklyn13",
+                            "avatar": {
+                                "image": "string",
+                                "uploaded_on": "2024-07-12T11:38:52.028856Z"
+                            }
+                        },
+                        "player1_score": 5,
+                        "player2_score": 7,
+                        "winner": {
+                            "id": 3,
+                            "username": "Brooklyn13",
+                            "avatar": {
+                                "image": "string",
+                                "uploaded_on": "2024-07-12T11:38:52.028856Z"
+                            }
+                        },
+                        "date": "2024-07-12T11:38:55.773283Z"
+                    }
+              )
+         ]
+    )
     def get(self, request, user_id, formant=None):
         try:
             player = User.objects.get(id=user_id)


### PR DESCRIPTION
Once you run make the docs are available at `http://localhost:8000/api/schema/swagger-ui/` and `http://localhost:8000/api/schema/redoc/`

In swagger-ui to get the authentication key you have to: 
- first run `POST /user/` (click "try it out" then change "string"s to something else) 
- then run `POST /api/token/` with the same `username` and `password` that you used in POST /user/
- then copy the `access token` from Response Body to the value field that you get when you press `Authorize` button on top right or one of the lock icons on any request

@jestebanpelaez18 To make the documentation easier (automatic) I think we should stick to viewsets ( You have already done that ). I used APIView in the Match API and documenting that makes the code look confusing.
