### PR TITLE
feat (JWTAuthenticationMiddleware): change to use query strings

### DIFF
--- a/backend/django_backend/django_backend/asgi.py
+++ b/backend/django_backend/django_backend/asgi.py
@@ -15,14 +15,14 @@ django_asgi_app = get_asgi_application()
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 
-from pong.middlewares import JWTAuthenticationMiddleware
+from .middlewares import JWTAuthenticationMiddleware
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_backend.settings')
 
 
 from django_backend.routing import websocket_urlpatterns
 
-# Remember for check the user online status the JWT should be uncomment 
+# Remember for check the user online status the JWT should be uncomment
 application = ProtocolTypeRouter({
     "http": django_asgi_app,
 	"websocket": AllowedHostsOriginValidator(

--- a/backend/django_backend/django_backend/middlewares.py
+++ b/backend/django_backend/django_backend/middlewares.py
@@ -1,18 +1,17 @@
 from channels.db import database_sync_to_async
 from channels.middleware import BaseMiddleware
 from rest_framework_simplejwt.tokens import UntypedToken
-from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth import get_user_model
 from jwt import decode as jwt_decode
 from django.conf import settings
+from urllib.parse import parse_qs
 
 User = get_user_model()
 
 @database_sync_to_async
 def get_user(validated_token):
 	try:
-		print(f"Validated token: {validated_token}")
 		user = get_user_model().objects.get(id=validated_token["user_id"])
 		return user
 
@@ -26,14 +25,11 @@ class JWTAuthenticationMiddleware(BaseMiddleware):
 	async def __call__(self, scope, receive, send):
 		# Extract the token from the query string or headers
 		try:
-			authorization = dict((x.decode('ascii').lower(), y.decode('ascii')) for x, y in scope['headers'])
-			token = authorization.get('authorization', '').split('Bearer ')[1] if 'authorization' in authorization else None
-			# print(f"Token: {token}", flush=True)
+			token = parse_qs(scope["query_string"].decode("utf8")).get('token', None)[0]
 			if (not token):
 				scope['user'] = AnonymousUser()
 				return await self.inner(scope, receive, send)
 			UntypedToken(token)
-			# print("Valid token", flush=True)
 			decoded_data = jwt_decode(token, settings.SECRET_KEY, algorithms=['HS256'])
 			scope['user'] = await get_user(decoded_data)
 		except:


### PR DESCRIPTION
Didn’t get browser to send authorization header when connecting to the server using websockets. So had to change it to use query strings ie. `/ws/hello/?token=sometoken`