### PR TITLE
Feature(Trn 121 reject friend request method in friends api)

### DIFF
--- a/backend/django_backend/friends/urls.py
+++ b/backend/django_backend/friends/urls.py
@@ -3,12 +3,13 @@ from rest_framework import routers
 from .views import FriendsViewSet
 
 router = routers.DefaultRouter()
-router.register('friends', FriendsViewSet, 'friend')
+router.register('api/friends/', FriendsViewSet, 'friend')
 
 urlpatterns = [
     path('', include(router.urls)),
     path('send_request/',FriendsViewSet.as_view({'post':'send_request'}), name='send_friend_request'),
     path('<int:pk>/accept_request/',FriendsViewSet.as_view({'post':'accept_request'}), name='accept_friend_request'),
     path('list/', FriendsViewSet.as_view({'get': 'list_friends'}), name='list_friends'),
-    path('list_request/', FriendsViewSet.as_view({'get': 'list_friends_request'}), name='list_friends_request'),   
+    path('list_request/', FriendsViewSet.as_view({'get': 'list_friends_request'}), name='list_friends_request'),
+    path('<int:pk>/reject_request/',FriendsViewSet.as_view({'post':'reject_request'}), name='reject_friend_request'),   
 ]

--- a/backend/django_backend/friends/views.py
+++ b/backend/django_backend/friends/views.py
@@ -125,12 +125,10 @@ class FriendsViewSet(viewsets.ModelViewSet):
             return Response({"Warning": "Anonimus User"}, status=status.HTTP_401_UNAUTHORIZED)
         try:
             friend_request = FriendRequest.objects.get(id=pk, to_user=request.user, accepted=False)
+            friend_request.delete()
         except FriendRequest.DoesNotExist:
             return Response({"Warning":"This Friend Request Does not Exist or has been accepted"}, status=status.HTTP_404_NOT_FOUND)
-        friend_request.accepted = True
-        friend_request.save()
-        serializer = FriendsSerializer(friend_request)
-        return Response({"detail": "Friend request accepted.","friend_request":serializer.data}, status=status.HTTP_200_OK)
+        return Response({"detail": "Friend request rejected."}, status=status.HTTP_200_OK)
     
 
             

--- a/backend/django_backend/friends/views.py
+++ b/backend/django_backend/friends/views.py
@@ -117,4 +117,20 @@ class FriendsViewSet(viewsets.ModelViewSet):
         friend_request.save()
         serializer = FriendsSerializer(friend_request)
         return Response({"detail": "Friend request accepted.","friend_request":serializer.data}, status=status.HTTP_200_OK)
+    
+    """Reject friend request"""
+    @action(detail=True, methods=['post'], permission_classes=[IsAuthenticatedOrCreateOnly, IsUser])
+    def reject_request(self,request, pk=None):
+        if not request.user.is_authenticated:
+            return Response({"Warning": "Anonimus User"}, status=status.HTTP_401_UNAUTHORIZED)
+        try:
+            friend_request = FriendRequest.objects.get(id=pk, to_user=request.user, accepted=False)
+        except FriendRequest.DoesNotExist:
+            return Response({"Warning":"This Friend Request Does not Exist or has been accepted"}, status=status.HTTP_404_NOT_FOUND)
+        friend_request.accepted = True
+        friend_request.save()
+        serializer = FriendsSerializer(friend_request)
+        return Response({"detail": "Friend request accepted.","friend_request":serializer.data}, status=status.HTTP_200_OK)
+    
+
             

--- a/backend/django_backend/friends/views.py
+++ b/backend/django_backend/friends/views.py
@@ -44,6 +44,13 @@ from user.models import OnlineStatus
 #   - Once it has identified these pending requests, we got the information from the serializer.
 #   - Finally, it returns the list of the pending the friends requests.
 
+# - reject_request: This method rejects a friend request, removing the friend request from the FriendRequest serializer. 
+#   Here's how it works:
+#   - The logged-in user who wants to accept the request must be authenticated.
+#   - The method takes the ID of the friend request and checks if it exists and has not yet been accepted (accepted=False).
+#   - The method remove the friend request from the FriendRequest Serializer
+#   - If the friend request does not exist or has already been accepted, an exception is thrown.
+
 class FriendsViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = FriendsSerializer


### PR DESCRIPTION
I created a new method the reject a friend request. So once you have rejected a friend request, the friend request is removed from the list of pending friend requests, meaning that the friend request does not exist anymore. 

You can test it in the same way as you test accept friend requests, the difference now is that we remove the friend request from the serializer. 