### PR TITLE
Trn 127 profile page changing to json format

### DIFF
--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -163,7 +163,7 @@ a {
   color: #060606;
 }
 
-.friends-profile {
+.profile {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -174,7 +174,7 @@ a {
   margin: 20px;
 }
 
-.friends-profile img {
+.profile img {
   width: 150px;
   height: 150px;
   border-radius: 50%;
@@ -188,7 +188,7 @@ a {
   margin: 5px ;
 }
 
-.friends-profile .status {
+.profile .status {
 	width: 10px;
 	height: 10px;
 	border-radius: 50%;
@@ -227,4 +227,11 @@ a {
   height: 10px;
   background-color: red;
   border-radius: 50%;
+}
+
+.msofd {
+  font-style: italic;
+  font-family: 'Courier New', Courier, monospace; /* Example of a different font */
+  color: #333; /* Optional: change the text color */
+  font-size: 0.8em; /* Optional: adjust the font size */
 }

--- a/frontend/static/css/index.css
+++ b/frontend/static/css/index.css
@@ -86,7 +86,7 @@ main {
 h1 {
   font-size: 40px;
   letter-spacing: 1px;
-  margin-left: 5px;
+  margin-left: 7px;
 }
 
 body {
@@ -135,6 +135,8 @@ p {
 }
 
 a {
+  margin-left: 5px;
+  display: block;
   color: #009579;
 }
 

--- a/frontend/static/js/views/Friends.js
+++ b/frontend/static/js/views/Friends.js
@@ -250,7 +250,7 @@ export default class Friends extends AView{
 		const profileHeader = this.createHeader('Friends', 'Friends', 'h1');
 		
 		const profileView = document.createElement('div');
-		profileView.classList.add('friends-profile');
+		profileView.classList.add('profile');
 		
 		const profileTitle = this.createHeader('Friends',`${friend.username}`, 'h3');
 		

--- a/frontend/static/js/views/Profile.js
+++ b/frontend/static/js/views/Profile.js
@@ -7,7 +7,7 @@ export default class extends AView {
 	}
 
 	async getHtml(){
-		const header = this.createHeader('header', 'Profile', 'h2');
+		const header = this.createHeader('header', 'Profile', 'h1');
 
 		const data = await this.fetchJsonData('static/js/views/profile.json');
 

--- a/frontend/static/js/views/Profile.js
+++ b/frontend/static/js/views/Profile.js
@@ -6,33 +6,53 @@ export default class extends AView {
 		this.setTitle("Profile");
 	}
 
-	fetchName(userData){
-		const base = document.createElement('section');
-		const name = this.userData.name;
-		base.textContent = name;
-		
-		return base;
-	}
+	async getHtml(){
+		const header = this.createHeader('header', 'Profile', 'h2');
 
-	fetchPicture(userData){
-		const img = document.createElement('img');
-		img.src = this.userData.pictureUrl;
-		img.width = 300;
-		img.width = 200;
-		return img;
-	}
+		const data = await this.fetchJsonData('static/js/views/profile.json');
 
-	async getHtml(userData){
-		const header = this.createHeader('header', 'testheader', 'h2');
-		const userNameBase = this.createParagraph('usernamebase');
-		const userName= this.fetchName(userData);
-		const profilePicutre = this.fetchPicture(userData);
-        const message = this.createParagraph('message');
+		const createProfile = this.showProfile(data);
         const settings = this.createLink('link2', 'Change settings from here', '/settings');
         const stats = this.createLink('link1', 'Change settings from here', '/stats');
 
 		window.localStorage.setItem('page', 'Profile');
-		this.updateView(header, userNameBase, userName, profilePicutre, message, settings, stats);
+		this.updateView(header, createProfile, settings, stats);
 		return ;
+	}
+
+	showProfile(my) {
+		
+		const profileView = document.createElement('div');
+		profileView.classList.add('profile');
+		
+		const profileTitle = this.createHeader('myProfile',`${my.username}`, 'h3');
+		
+		const profileAvatar = document.createElement('img');
+		profileAvatar.src = my.profile.avatar;
+		profileAvatar.alt = `${my.username}'s avatar`;
+		
+		const wins = my.wins;
+		const loss = my.loses;
+		const gameHistoryText = `Win: ${wins}🏆\tLoss: ${loss}💀`;
+		const gameHistory = this.createParagraph('game-history', gameHistoryText);
+
+		let msg;
+
+		if (wins > loss)
+			msg = "Amazing! You are doing great";
+		else if (wins < loss)
+			msg = "Shall we play more to get some wins?";
+		else
+			msg = "We are even steven. Let's play some more!";
+
+		const msofd = this.createParagraph('msofd', msg);
+		msofd.classList.add('msofd');
+		
+		profileView.appendChild(profileTitle);
+		profileView.appendChild(profileAvatar);
+		profileView.appendChild(gameHistory);
+		profileView.appendChild(msofd);
+		
+		return profileView;
 	}
 }

--- a/frontend/static/js/views/Profile.js
+++ b/frontend/static/js/views/Profile.js
@@ -4,12 +4,6 @@ export default class extends AView {
 	constructor(params){
 		super(params);//call the constructor of the parent class
 		this.setTitle("Profile");
-		
-		this.userData = {
-			name: 'Test Name',
-			email: 'testmail@test.com',
-			pictureUrl: 'https://snworksceo.imgix.net/drt/7a10426e-6523-4304-8532-2d230f9bab9b.sized-1000x1000.jpg?w=1000&dpr=2'
-		};
 	}
 
 	fetchName(userData){
@@ -19,15 +13,7 @@ export default class extends AView {
 		
 		return base;
 	}
-	
-	fetchEmail(userData){
-		const base = document.createElement('section');
-		const email = this.userData.email;
-		base.textContent = email;
-		
-		return base;
-	}
-	
+
 	fetchPicture(userData){
 		const img = document.createElement('img');
 		img.src = this.userData.pictureUrl;
@@ -40,15 +26,13 @@ export default class extends AView {
 		const header = this.createHeader('header', 'testheader', 'h2');
 		const userNameBase = this.createParagraph('usernamebase');
 		const userName= this.fetchName(userData);
-		const userEmailBase = this.createParagraph('emailbase');
-		const userEmail = this.fetchEmail(userData);
 		const profilePicutre = this.fetchPicture(userData);
         const message = this.createParagraph('message');
         const settings = this.createLink('link2', 'Change settings from here', '/settings');
         const stats = this.createLink('link1', 'Change settings from here', '/stats');
 
 		window.localStorage.setItem('page', 'Profile');
-		this.updateView(header, userNameBase, userName, userEmailBase, userEmail, profilePicutre, message, settings, stats);
+		this.updateView(header, userNameBase, userName, profilePicutre, message, settings, stats);
 		return ;
 	}
 }

--- a/frontend/static/js/views/profile.json
+++ b/frontend/static/js/views/profile.json
@@ -1,0 +1,9 @@
+{
+	"id": "2",
+	"username": "Logged In User",
+	"profile": {
+		"avatar": "https://picsum.photos/200"
+	},
+	"wins": "2",
+	"loses": "3"
+}


### PR DESCRIPTION
<img width="1050" alt="Screenshot 2024-07-17 at 16 50 35" src="https://github.com/user-attachments/assets/207f91a1-bcad-43e2-81e0-e724a38e6c75">

Profile page now takes in json data and update the view. Design is aligned with friend's profile looks.
This is using mock json data(profile.json), needs confirm from backend if this is good to go. match history part is not added yet.
{
	"id": "2",
	"username": "Logged In User",
	"profile": {
		"avatar": "https://picsum.photos/200"
	},
	"wins": "2",
	"loses": "3"
}

Translation that needs to be added in the profile page will be done in the same branch where I will add translation to friend.js