### PR TITLE
Trn 136 language selector fix

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,6 @@
     <title>PLAY PONG</title>
     <link rel="stylesheet" href="/static/css/index.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <!-- <script defer src = "/static/js/login.js"></script> -->
 </head>
 <!-- <body class="login">
@@ -40,6 +39,7 @@
         <a href = "/pong" class="nave__link" data-link>Pong</a><br>
         <a href = "/settings" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
+            <option selected> Language</option>
             <option value="English" language="english" lang-toggle>English</option>
             <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
             <option value="Spanish" language="spanish" lang-toggle>Spanish</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,7 @@
     <title>PLAY PONG</title>
     <link rel="stylesheet" href="/static/css/index.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <!-- <script defer src = "/static/js/login.js"></script> -->
 </head>
 <!-- <body class="login">
@@ -38,7 +39,7 @@
         <a href = "/friends" class="nave__link" data-link>Friends</a><br>
         <a href = "/pong" class="nave__link" data-link>Pong</a><br>
         <a href = "/settings" class="nave__link" data-link>Settings</a><br>
-        <select id="languageSelect" lang-toggle>
+        <select name="language select" id="languageSelect" lang-toggle>
             <option value="English" language="english" lang-toggle>English</option>
             <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
             <option value="Spanish" language="spanish" lang-toggle>Spanish</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,12 +38,6 @@
         <a href = "/friends" lang-key="friends-nav" class="nave__link" data-link>Friends</a><br>
         <a href = "/pong" lang-key="pong-nav" class="nave__link" data-link>Pong</a><br>
         <a href = "/settings" lang-key="settings-nav" class="nave__link" data-link>Settings</a><br>
-        <select name="language select" id="languageSelect" lang-toggle>
-            <option selected lang-key="language">Language</option>
-            <option value="English" language="english" lang-toggle>English</option>
-            <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
-            <option value="Spanish" language="spanish" lang-toggle>Spanish</option>
-        </select>
     </nav>
 	<main id="cont"></main> 
 	<script type="module" src="static/js/index.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,12 +32,12 @@
 <body>
     <nav class="nav">
         <a href = "/" class="nave__link" data-link></a><br>
-        <a href = "/login" lang-key="login" class="nave__link" data-link>Login</a><br>
-        <a href = "/dashboard" lang-key="dashboard" class="nave__link" data-link>Dashboard</a><br>
-        <a href = "/profile" lang-key="profile" class="nave__link" data-link>Profile</a><br>
-        <a href = "/friends" lang-key="friends" class="nave__link" data-link>Friends</a><br>
-        <a href = "/pong" lang-key="pong" class="nave__link" data-link>Pong</a><br>
-        <a href = "/settings" lang-key="settings" class="nave__link" data-link>Settings</a><br>
+        <a href = "/login" lang-key="login-nav" class="nave__link" data-link>Login</a><br>
+        <a href = "/dashboard" lang-key="dashboard-nav" class="nave__link" data-link>Dashboard</a><br>
+        <a href = "/profile" lang-key="profile-nav" class="nave__link" data-link>Profile</a><br>
+        <a href = "/friends" lang-key="friends-nav" class="nave__link" data-link>Friends</a><br>
+        <a href = "/pong" lang-key="pong-nav" class="nave__link" data-link>Pong</a><br>
+        <a href = "/settings" lang-key="settings-nav" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
             <option selected lang-key="language"> Language</option>
             <option value="English" language="english" lang-toggle>English</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,7 +37,7 @@
         <a href = "/profile" lang-key="profile" class="nave__link" data-link>Profile</a><br>
         <a href = "/friends" lang-key="friends" class="nave__link" data-link>Friends</a><br>
         <a href = "/pong" lang-key="pong" class="nave__link" data-link>Pong</a><br>
-        <a href = "/settings" lang-key="asetukset" class="nave__link" data-link>Settings</a><br>
+        <a href = "/settings" lang-key="settings" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
             <option selected lang-key="language"> Language</option>
             <option value="English" language="english" lang-toggle>English</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,14 +32,14 @@
 <body>
     <nav class="nav">
         <a href = "/" class="nave__link" data-link></a><br>
-        <a href = "/login" class="nave__link" data-link>Login</a><br>
-        <a href = "/dashboard" class="nave__link" data-link>Dashboard</a><br>
-        <a href = "/profile" class="nave__link" data-link>Profile</a><br>
-        <a href = "/friends" class="nave__link" data-link>Friends</a><br>
-        <a href = "/pong" class="nave__link" data-link>Pong</a><br>
-        <a href = "/settings" class="nave__link" data-link>Settings</a><br>
+        <a href = "/login" lang-key="login" class="nave__link" data-link>Login</a><br>
+        <a href = "/dashboard" lang-key="dashboard" class="nave__link" data-link>Dashboard</a><br>
+        <a href = "/profile" lang-key="profile" class="nave__link" data-link>Profile</a><br>
+        <a href = "/friends" lang-key="friends" class="nave__link" data-link>Friends</a><br>
+        <a href = "/pong" lang-key="pong" class="nave__link" data-link>Pong</a><br>
+        <a href = "/settings" lang-key="asetukset" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
-            <option selected > Language</option>
+            <option selected lang-key="language"> Language</option>
             <option value="English" language="english" lang-toggle>English</option>
             <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
             <option value="Spanish" language="spanish" lang-toggle>Spanish</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,7 +39,7 @@
         <a href = "/pong" lang-key="pong-nav" class="nave__link" data-link>Pong</a><br>
         <a href = "/settings" lang-key="settings-nav" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
-            <option selected lang-key="language"> Language</option>
+            <option selected lang-key="language">Language</option>
             <option value="English" language="english" lang-toggle>English</option>
             <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
             <option value="Spanish" language="spanish" lang-toggle>Spanish</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,7 +39,7 @@
         <a href = "/pong" class="nave__link" data-link>Pong</a><br>
         <a href = "/settings" class="nave__link" data-link>Settings</a><br>
         <select name="language select" id="languageSelect" lang-toggle>
-            <option selected> Language</option>
+            <option selected > Language</option>
             <option value="English" language="english" lang-toggle>English</option>
             <option value="Finnish" language="finnish" lang-toggle>Finnish</option>
             <option value="Spanish" language="spanish" lang-toggle>Spanish</option>

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -83,7 +83,7 @@ const router = async () => {
 };
 
 window.onload = (event) => {
-	if (window.localStorage.getItem('language') == null){
+	if (window.localStorage.getItem('language') === null){
 		window.localStorage.setItem('language', 'english');
 	}
 };
@@ -92,7 +92,7 @@ window.addEventListener("popstate", router);
 //this will listen for back and forward buttons in the browser
 // Dynamically import the translation file
 document.addEventListener("viewUpdated", () => {
-	if (localStorage.getItem('language') == 'language'){
+	if (localStorage.getItem('language') === 'language'){
 		return;
 	}
 	const page = window.localStorage.getItem('page');

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -104,16 +104,15 @@ function updateTranslations(page){
    .then(data => {
         translations = JSON.parse(data);
 		const language = window.localStorage.getItem('language');
-		const currentTranslations = translations[language]; // Store the imported translations
+		const currentTranslations = translations[language];
 		updateTranslationElements(currentTranslations);
 	})
 }
 
-function updateTranslationElements(currentTranslations){ 
+function updateTranslationElements(currentTranslations){
 		const elementsToTranslate = document.querySelectorAll('[lang-key]');
 			elementsToTranslate.forEach(element => {
 				const key = element.getAttribute('lang-key');
-				console.log(key);
 				if (currentTranslations[key]) {
 					element.textContent = currentTranslations[key];
 				}

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -107,8 +107,6 @@ function updateTranslations(page){
    .then(data => {
         translations = JSON.parse(data);
 		const language = window.localStorage.getItem('language');
-		console.log('language in local storage');
-		console.log(language);
 		const currentTranslations = translations[language];
 		updateTranslationElements(currentTranslations);
 	})
@@ -118,10 +116,6 @@ function updateTranslationElements(currentTranslations){
 		const elementsToTranslate = document.querySelectorAll('[lang-key]');
 			elementsToTranslate.forEach(element => {
 				const key = element.getAttribute('lang-key');
-				console.log('key');
-				console.log(key);
-				console.log('currentTranslations[key]');
-				console.log(currentTranslations[key]);
 				if (currentTranslations[key]) {
 					element.textContent = currentTranslations[key];
 				}

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -92,6 +92,9 @@ window.addEventListener("popstate", router);
 //this will listen for back and forward buttons in the browser
 // Dynamically import the translation file
 document.addEventListener("viewUpdated", () => {
+	if (localStorage.getItem('language') == 'language'){
+		return;
+	}
 	const page = window.localStorage.getItem('page');
 	updateTranslations('index');
 	updateTranslations(page);
@@ -104,6 +107,8 @@ function updateTranslations(page){
    .then(data => {
         translations = JSON.parse(data);
 		const language = window.localStorage.getItem('language');
+		console.log('language in local storage');
+		console.log(language);
 		const currentTranslations = translations[language];
 		updateTranslationElements(currentTranslations);
 	})
@@ -113,6 +118,10 @@ function updateTranslationElements(currentTranslations){
 		const elementsToTranslate = document.querySelectorAll('[lang-key]');
 			elementsToTranslate.forEach(element => {
 				const key = element.getAttribute('lang-key');
+				console.log('key');
+				console.log(key);
+				console.log('currentTranslations[key]');
+				console.log(currentTranslations[key]);
 				if (currentTranslations[key]) {
 					element.textContent = currentTranslations[key];
 				}

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -92,24 +92,33 @@ window.addEventListener("popstate", router);
 //this will listen for back and forward buttons in the browser
 // Dynamically import the translation file
 document.addEventListener("viewUpdated", () => {
-    let translations;
 	const page = window.localStorage.getItem('page');
+	updateTranslations('index');
+	updateTranslations(page);
+});
+
+function updateTranslations(page){
+	let translations;
     fetch('./static/translations/' + page + '.json')
    .then(response => response.text())
    .then(data => {
         translations = JSON.parse(data);
 		const language = window.localStorage.getItem('language');
 		const currentTranslations = translations[language]; // Store the imported translations
-        const elementsToTranslate = document.querySelectorAll('[lang-key]');
-		elementsToTranslate.forEach(element => {
-            const key = element.getAttribute('lang-key');
-            if (currentTranslations[key]) {
-				element.textContent = currentTranslations[key];
-            }
-        });
-    })
-   .catch(error => console.error('Error loading translation file:', error));
-});
+		updateTranslationElements(currentTranslations);
+	})
+}
+
+function updateTranslationElements(currentTranslations){ 
+		const elementsToTranslate = document.querySelectorAll('[lang-key]');
+			elementsToTranslate.forEach(element => {
+				const key = element.getAttribute('lang-key');
+				console.log(key);
+				if (currentTranslations[key]) {
+					element.textContent = currentTranslations[key];
+				}
+			});
+}
 
 document.addEventListener("DOMContentLoaded", () => {
 	document.body.addEventListener("click", e => {

--- a/frontend/static/js/views/Settings.js
+++ b/frontend/static/js/views/Settings.js
@@ -16,7 +16,6 @@ export default class extends AView {
 		const usernameInput = textInputField('username', 'Username', 'username', 'text');
 		const passwordInput = textInputField('password', 'Password', 'password', 'password');
 		const confirmPasswordInput = textInputField('password-again', 'Confirm password', 'confirm-password', 'password');
-		const paragraph = this.createParagraph('language');
 		const signupButton = this.createButton('savebutton', 'save', 'save');
 		
 		form.appendChild(usernameInput);

--- a/frontend/static/js/views/Settings.js
+++ b/frontend/static/js/views/Settings.js
@@ -42,7 +42,7 @@ export default class extends AView {
 		});
 
 		window.localStorage.setItem('page', 'Settings');
-		this.updateView(title, form, paragraph, buttonDel);
+		this.updateView(title, form, buttonDel);
 		return ;
 	}
 

--- a/frontend/static/js/views/Settings.js
+++ b/frontend/static/js/views/Settings.js
@@ -27,6 +27,24 @@ export default class extends AView {
 		const select = document.createElement('select');
 		select.setAttribute('id', 'languageSelect');
 		select.classList.add('translations');
+		const option = document.createElement('option');
+		option.selected = 'Language';
+		option.setAttribute('lang-key', 'language');
+		select.appendChild(option);
+		['English', 'Finnish', 'Spanish'].forEach((lang) => {
+			const option = document.createElement('option');
+            option.text = lang;
+			option.setAttribute('lang-key', lang);
+            select.appendChild(option);
+		});
+		if(select){
+			  select.addEventListener('change', (event) => {
+				const selectedLanguage = event.target.value;
+				const language = selectedLanguage.toLowerCase();
+				window.localStorage.setItem('language', language);
+				document.dispatchEvent(new CustomEvent('viewUpdated'));
+			})
+		}
 
 		const buttonDel = this.createButton('deletebutton', 'delete', 'delete account');
 		buttonDel.addEventListener('click', (event) => {
@@ -42,7 +60,7 @@ export default class extends AView {
 		});
 
 		window.localStorage.setItem('page', 'Settings');
-		this.updateView(title, form, buttonDel);
+		this.updateView(title, form, select, buttonDel);
 		return ;
 	}
 

--- a/frontend/static/js/views/Settings.js
+++ b/frontend/static/js/views/Settings.js
@@ -28,12 +28,18 @@ export default class extends AView {
 		const select = document.createElement('select');
 		select.setAttribute('id', 'languageSelect');
 		select.classList.add('translations');
+
+		const option = document.createElement('option');
+		option.selected = 'Language';
+		option.setAttribute('lang-key', 'language');
+		select.appendChild(option);
 		['English', 'Finnish', 'Spanish'].forEach((lang) => {
 			const option = document.createElement('option');
             option.text = lang;
 			option.setAttribute('lang-key', lang);
             select.appendChild(option);
 		});
+
 		if(select){
 			  select.addEventListener('change', (event) => {
 				const selectedLanguage = event.target.value;

--- a/frontend/static/js/views/Settings.js
+++ b/frontend/static/js/views/Settings.js
@@ -29,26 +29,6 @@ export default class extends AView {
 		select.setAttribute('id', 'languageSelect');
 		select.classList.add('translations');
 
-		const option = document.createElement('option');
-		option.selected = 'Language';
-		option.setAttribute('lang-key', 'language');
-		select.appendChild(option);
-		['English', 'Finnish', 'Spanish'].forEach((lang) => {
-			const option = document.createElement('option');
-            option.text = lang;
-			option.setAttribute('lang-key', lang);
-            select.appendChild(option);
-		});
-
-		if(select){
-			  select.addEventListener('change', (event) => {
-				const selectedLanguage = event.target.value;
-				const language = selectedLanguage.toLowerCase();
-				window.localStorage.setItem('language', language);
-				document.dispatchEvent(new CustomEvent('viewUpdated'));
-			})
-		}
-		
 		const buttonDel = this.createButton('deletebutton', 'delete', 'delete account');
 		buttonDel.addEventListener('click', (event) => {
 			event.preventDefault();
@@ -63,7 +43,7 @@ export default class extends AView {
 		});
 
 		window.localStorage.setItem('page', 'Settings');
-		this.updateView(title, form, paragraph, select, buttonDel);
+		this.updateView(title, form, paragraph, buttonDel);
 		return ;
 	}
 

--- a/frontend/static/translations/Settings.json
+++ b/frontend/static/translations/Settings.json
@@ -6,6 +6,7 @@
 		"password": "salasana: ",
 		"password-again": "salasana uudelleen: ",
 		"savebutton": "tallenna muutokset",
+		"language": "kieli",
 		"deletebutton": "poista käyttäjä "
 	},
 
@@ -16,6 +17,7 @@
 		"password": "password: ",
 		"password-again": "password again: ",
 		"savebutton": "save changes",
+		"language": "language",
 		"deletebutton": "delete account "
 	},
 
@@ -26,6 +28,7 @@
 		"password": "contraseña: ",
 		"password-again": "contraseña de nuevo: ",
 		"savebutton": "ahorrar",
+		"language": "language in spanish",
 		"deletebutton": "delete account in spanish "
 	}
 

--- a/frontend/static/translations/Settings.json
+++ b/frontend/static/translations/Settings.json
@@ -5,7 +5,6 @@
 		"username": "käyttäjätunnus: ",
 		"password": "salasana: ",
 		"password-again": "salasana uudelleen: ",
-		"language": "kieli: ",
 		"savebutton": "tallenna muutokset",
 		"deletebutton": "poista käyttäjä "
 	},
@@ -16,7 +15,6 @@
 		"username": "username: ",
 		"password": "password: ",
 		"password-again": "password again: ",
-		"language": "language: ",
 		"savebutton": "save changes",
 		"deletebutton": "delete account "
 	},
@@ -27,7 +25,6 @@
 		"username": "nombre de usuario: ",
 		"password": "contraseña: ",
 		"password-again": "contraseña de nuevo: ",
-		"language": "idioma: ",
 		"savebutton": "ahorrar",
 		"deletebutton": "delete account in spanish "
 	}

--- a/frontend/static/translations/index.json
+++ b/frontend/static/translations/index.json
@@ -1,6 +1,7 @@
 {
 	"finnish":
 	{
+		"language": "Kieli ",
 		"login-nav": "Kirjaudu sisään ",
 		"dashboard-nav": "Etusivu",
 		"profile-nav": "Profiili",
@@ -11,6 +12,7 @@
 
 	"english":
 	{
+		"language": "Language",
 		"login-nav": "Login",
 		"dashboard-nav": "Dashboard",
 		"profile-nav": "Profile",
@@ -20,6 +22,7 @@
 
 	"spanish":
 	{
+		"language": "Kieli in spanish",
 		"login-nav": "Acceso",
 		"dashboard-nav": "Página principal",
 		"profile-nav": "Perfil",

--- a/frontend/static/translations/index.json
+++ b/frontend/static/translations/index.json
@@ -1,0 +1,30 @@
+{
+	"finnish":
+	{
+		"login": "käyttäjätunnus: ",
+		"dashboard": "Etusivu",
+		"profile": "Profiili",
+		"friends": "Kaverit",
+		"settings": "Asetukset"
+
+	},
+
+	"english":
+	{
+		"login": "Login",
+		"dashboard": "Dashboard",
+		"profile": "Profile",
+		"friends": "Friends",
+		"settings": "Settings"
+	},
+
+	"spanish":
+	{
+		"login": "käyttäjätunnus: ",
+		"dashboard": "KIRJAUDU SISÄÄN",
+		"profile": "rekisteröidy täältä",
+		"friends": "rekisteröidy täältä",
+		"settings": "Etkö ole rekisteröitynyt?"
+	}
+
+}

--- a/frontend/static/translations/index.json
+++ b/frontend/static/translations/index.json
@@ -1,7 +1,7 @@
 {
 	"finnish":
 	{
-		"login": "käyttäjätunnus: ",
+		"login": "Kirjaudu sisään ",
 		"dashboard": "Etusivu",
 		"profile": "Profiili",
 		"friends": "Kaverit",
@@ -20,11 +20,10 @@
 
 	"spanish":
 	{
-		"login": "käyttäjätunnus: ",
-		"dashboard": "KIRJAUDU SISÄÄN",
-		"profile": "rekisteröidy täältä",
-		"friends": "rekisteröidy täältä",
-		"settings": "Etkö ole rekisteröitynyt?"
+		"login": "Acceso",
+		"dashboard": "Página principal",
+		"profile": "Perfil",
+		"friends": "Amigas",
+		"settings": "Ajustes"
 	}
-
 }

--- a/frontend/static/translations/index.json
+++ b/frontend/static/translations/index.json
@@ -1,29 +1,29 @@
 {
 	"finnish":
 	{
-		"login": "Kirjaudu sisään ",
-		"dashboard": "Etusivu",
-		"profile": "Profiili",
-		"friends": "Kaverit",
-		"settings": "Asetukset"
+		"login-nav": "Kirjaudu sisään ",
+		"dashboard-nav": "Etusivu",
+		"profile-nav": "Profiili",
+		"friends-nav": "Kaverit",
+		"settings-nav": "Asetukset"
 
 	},
 
 	"english":
 	{
-		"login": "Login",
-		"dashboard": "Dashboard",
-		"profile": "Profile",
-		"friends": "Friends",
-		"settings": "Settings"
+		"login-nav": "Login",
+		"dashboard-nav": "Dashboard",
+		"profile-nav": "Profile",
+		"friends-nav": "Friends",
+		"settings-nav": "Settings"
 	},
 
 	"spanish":
 	{
-		"login": "Acceso",
-		"dashboard": "Página principal",
-		"profile": "Perfil",
-		"friends": "Amigas",
-		"settings": "Ajustes"
+		"login-nav": "Acceso",
+		"dashboard-nav": "Página principal",
+		"profile-nav": "Perfil",
+		"friends-nav": "Amigas",
+		"settings-nav": "Ajustes"
 	}
 }


### PR DESCRIPTION
<img width="690" alt="Screenshot 2024-07-22 at 16 21 51" src="https://github.com/user-attachments/assets/feb172c6-fda6-4670-b538-dad3c2d69e4f">

- Added translations to effect also the navbar
- Added translation file to translate the navbar (index.json). This can later also be used for any other static elements, that always show on our site.
- Language selector now shows 'language' as the top option, done so refreshing page won't default to show 'English' in the selector when the page in fact is in Finnish. 
- Removed language selector from the settings, it's better to only have it in one page to avoid confusion.