### PR TITLE
Trn 138 fix pong paddles getting stuck on the top of the borders

### DIFF
--- a/backend/django_backend/pong/pong_game/ball.py
+++ b/backend/django_backend/pong/pong_game/ball.py
@@ -10,13 +10,6 @@ class Ball(Collider):
 		self.width: int = 5
 		self.height: int = 5
 
-	# def intersects(self, other) -> None:
-    #     return (self.x < other.x + other.width and
-    #             self.x + self.width > other.x and
-    #             self.y < other.y + other.height and
-    #             self.y + self.height > other.y)
-
-
 	def update_position(self) -> None:
 		self.x += self.dx
 		self.y += self.dy

--- a/backend/django_backend/pong/pong_game/ball.py
+++ b/backend/django_backend/pong/pong_game/ball.py
@@ -10,6 +10,12 @@ class Ball(Collider):
 		self.width: int = 5
 		self.height: int = 5
 
+	# def intersects(self, other) -> None:
+    #     return (self.x < other.x + other.width and
+    #             self.x + self.width > other.x and
+    #             self.y < other.y + other.height and
+    #             self.y + self.height > other.y)
+
 
 	def update_position(self) -> None:
 		self.x += self.dx

--- a/backend/django_backend/pong/pong_game/ball.py
+++ b/backend/django_backend/pong/pong_game/ball.py
@@ -10,12 +10,6 @@ class Ball(Collider):
 		self.width: int = 5
 		self.height: int = 5
 
-	# def intersects(self, other) -> None:
-    #     return (self.x < other.x + other.width and
-    #             self.x + self.width > other.x and
-    #             self.y < other.y + other.height and
-    #             self.y + self.height > other.y)
-
 
 	def update_position(self) -> None:
 		self.x += self.dx

--- a/backend/django_backend/pong/pong_game/player.py
+++ b/backend/django_backend/pong/pong_game/player.py
@@ -22,22 +22,18 @@ class Player(Collider):
 		elif direction == "down":
 			self.move_down = True
 
-	# def intersects(self, other) -> None:
-	# 	# Check if two rectangles intersect
-    #     return (self.x < other.x + other.width and
-    #             self.x + self.width > other.x and
-    #             self.y < other.y + other.height and
-    #             self.y + self.height > other.y)
 
 	def update_position(self) -> None:
 		if self.move_up:
-			if (self.y >= consts.MAP_HEIGHT - 6):
+			if (self.y >= consts.MAP_HEIGHT - 11):
+				self.y -= 1
 				return
-			self.y += 5
+			self.y += 4
 			self.move_up = False
 
 		elif self.move_down:
-			if (self.y <= 0 + 6):
+			if (self.y <= 0 + 11):
+				self.y += 1
 				return
-			self.y -= 5
+			self.y -= 4
 			self.move_down = False


### PR DESCRIPTION
Paddles can now go up and down to their heart's content without getting stuck. 
This was fixed by changing the behavior when the paddle encounters the border. It now moves the paddle back by a small amount to compensate for the borders. 

The intersect function in ball.py and player.py was also removed as it was not being used.